### PR TITLE
Fix newly enforce lints and clean pubspec

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ dart:
 
 dart_task:
   - test
-  - dartanalyzer
+  - dartanalyzer: --fatal-infos --fatal-warnings .
 
 # Only run one instance of the formatter and the analyzer, rather than running
 # them against each Dart version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 1.0.5-dev
+
 ## 1.0.4
 
 * Set max SDK version to `<3.0.0`, and adjust other dependencies.

--- a/lib/test_process.dart
+++ b/lib/test_process.dart
@@ -123,7 +123,7 @@ class TestProcess {
             .transform(const LineSplitter())) {
     addTearDown(_tearDown);
     expect(_process.exitCode.then((_) => _logOutput()), completes,
-        reason: "Process `$description` never exited.");
+        reason: 'Process `$description` never exited.');
 
     _stdout = StreamQueue(stdoutStream());
     _stderr = StreamQueue(stderrStream());
@@ -135,12 +135,12 @@ class TestProcess {
     // [stdoutStream] or [stderrStream] output.
     _stdoutSplitter.split().listen((line) {
       if (forwardStdio) print(line);
-      _log.add("    $line");
+      _log.add('    $line');
     });
 
     _stderrSplitter.split().listen((line) {
       if (forwardStdio) print(line);
-      _log.add("[e] $line");
+      _log.add('[e] $line');
     });
   }
 
@@ -168,14 +168,14 @@ class TestProcess {
     await Future.delayed(Duration.zero);
 
     var buffer = StringBuffer();
-    buffer.write("Process `$description` ");
+    buffer.write('Process `$description` ');
     if (exitCodeOrNull == null) {
-      buffer.writeln("was killed with SIGKILL in a tear-down. Output:");
+      buffer.writeln('was killed with SIGKILL in a tear-down. Output:');
     } else {
-      buffer.writeln("exited with exitCode $exitCodeOrNull. Output:");
+      buffer.writeln('exited with exitCode $exitCodeOrNull. Output:');
     }
 
-    buffer.writeln(_log.join("\n"));
+    buffer.writeln(_log.join('\n'));
     printOnFailure(buffer.toString());
   }
 
@@ -230,6 +230,6 @@ class TestProcess {
     var exitCode = await this.exitCode;
     if (expectedExitCode == null) return;
     expect(exitCode, expectedExitCode,
-        reason: "Process `$description` had an unexpected exit code.");
+        reason: 'Process `$description` had an unexpected exit code.');
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,17 +2,16 @@ name: test_process
 version: 1.0.5-dev
 
 description: A package for testing subprocesses.
-author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/test_process
 
 environment:
   sdk: '>=2.0.0 <3.0.0'
 
 dependencies:
-  async: '>=1.12.0 <3.0.0'
-  meta: '>=0.9.0 <2.0.0'
+  async: ^2.0.0
+  meta: ^1.0.0
   path: ^1.0.0
-  test: '>=0.12.42 <2.0.0'
+  test: ^1.0.0
 
 dev_dependencies:
   pedantic: ^1.0.0

--- a/test/test_process_test.dart
+++ b/test/test_process_test.dart
@@ -14,34 +14,34 @@ import 'package:test_process/test_process.dart';
 final throwsTestFailure = throwsA(TypeMatcher<TestFailure>());
 
 void main() {
-  group("shouldExit()", () {
-    test("succeeds when the process exits with the given exit code", () async {
+  group('shouldExit()', () {
+    test('succeeds when the process exits with the given exit code', () async {
       var process = await startDartProcess('exitCode = 42;');
       expect(process.exitCode, completion(equals(42)));
       await process.shouldExit(greaterThan(12));
     });
 
-    test("fails when the process exits with a different exit code", () async {
+    test('fails when the process exits with a different exit code', () async {
       var process = await startDartProcess('exitCode = 1;');
       expect(process.exitCode, completion(equals(1)));
       expect(process.shouldExit(greaterThan(12)), throwsTestFailure);
     });
 
-    test("allows any exit code without an assertion", () async {
+    test('allows any exit code without an assertion', () async {
       var process = await startDartProcess('exitCode = 1;');
       expect(process.exitCode, completion(equals(1)));
       await process.shouldExit();
     });
   });
 
-  test("kill() stops the process", () async {
+  test('kill() stops the process', () async {
     var process = await startDartProcess('while (true);');
 
     // Should terminate.
     await process.kill();
   });
 
-  group("stdout and stderr", () {
+  group('stdout and stderr', () {
     test("expose the process's standard io", () async {
       var process = await startDartProcess(r'''
         print("hello");
@@ -54,7 +54,7 @@ void main() {
       await process.shouldExit(0);
     });
 
-    test("close when the process exits", () async {
+    test('close when the process exits', () async {
       var process = await startDartProcess('');
       expect(expectLater(process.stdout, emits('hello')), throwsTestFailure);
       expect(expectLater(process.stderr, emits('world')), throwsTestFailure);
@@ -85,19 +85,19 @@ void main() {
     expect(process.stderrStream(), emitsInOrder(['hi', emitsDone]));
   });
 
-  test("stdin writes to the process", () async {
+  test('stdin writes to the process', () async {
     var process = await startDartProcess(r'''
       stdinLines.listen((line) => print("> $line"));
     ''');
 
-    process.stdin.writeln("hello");
-    await expectLater(process.stdout, emits("> hello"));
-    process.stdin.writeln("world");
-    await expectLater(process.stdout, emits("> world"));
+    process.stdin.writeln('hello');
+    await expectLater(process.stdout, emits('> hello'));
+    process.stdin.writeln('world');
+    await expectLater(process.stdout, emits('> world'));
     await process.kill();
   });
 
-  test("signal sends a signal to the process", () async {
+  test('signal sends a signal to the process', () async {
     var process = await startDartProcess(r'''
       ProcessSignal.sighup.watch().listen((_) => print("HUP"));
       print("ready");
@@ -107,7 +107,7 @@ void main() {
     process.signal(ProcessSignal.sighup);
     await expectLater(process.stdout, emits('HUP'));
     await process.kill();
-  }, testOn: "!windows");
+  }, testOn: '!windows');
 }
 
 /// Starts a Dart process running [script] in a main method.


### PR DESCRIPTION
- Fix `prefer_single_quotes` which is now enforced by `package:pedantic`
- Add a blank CHANGELOG section so it matches pubspec.
- Remove unused author section from pubspec.
- Simplify constraints on packages that had an unnecessarily low lower
  bound. Each of these packages doesn't support the Dart 2 stable SDK
  before their latest major version number.
- Fail travis for warnings and lints.