### PR TITLE
Remove unused dart:async import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.0.0
+  - 2.1.0
   - dev
 
 dart_task:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.6
+
+* Require Dart >=2.1
+
 ## 1.0.5
 
 * Don't allow the test to time out as long as the process is emitting output.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: test_process
-version: 1.0.5
+version: 1.0.6-dev
 
 description: A package for testing subprocesses.
 homepage: https://github.com/dart-lang/test_process
 
 environment:
-  sdk: '>=2.0.0 <3.0.0'
+  sdk: '>=2.1.0 <3.0.0'
 
 dependencies:
   async: ^2.0.0

--- a/test/test_process_test.dart
+++ b/test/test_process_test.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:io';
 
 import 'package:path/path.dart' as p;


### PR DESCRIPTION
Since Dart 2.1, Future and Stream have been exported from dart:core