### PR TITLE
Prepare to publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
-## 2.0.0-nullsafety.0
+## 2.0.0
 
 * Migrate to null safety.
-* Require Dart >=2.12.
 
 ## 1.0.6
 


### PR DESCRIPTION
Fix the version in the changelog and remove redundant entry. Migrating
to null safety implies changing the SDK constraint.