### PR TITLE
Remove expectation of process exit in test body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.1.0-wip
+
+- Remove the expectation that the process exits during the normal test body.
+  The process will still be killed during teardown if it has not exited. The
+  check can be manually restored with `shouldExit()`.
+
 ## 2.0.3
 
 - Populate the pubspec `repository` field.

--- a/lib/test_process.dart
+++ b/lib/test_process.dart
@@ -119,8 +119,8 @@ class TestProcess {
             .transform(encoding.decoder)
             .transform(const LineSplitter())) {
     addTearDown(_tearDown);
-    expect(_process.exitCode.then((_) => _logOutput()), completes,
-        reason: 'Process `$description` never exited.');
+
+    _process.exitCode.whenComplete(_logOutput);
 
     // Listen eagerly so that the lines are interleaved properly between the two
     // streams.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: test_process
-version: 2.0.3
+version: 2.1.0-wip
 description:
   "Test processes: starting; validating stdout and stderr; checking exit code"
 repository: https://github.com/dart-lang/test_process

--- a/test/test_process_test.dart
+++ b/test/test_process_test.dart
@@ -107,6 +107,13 @@ void main() {
     await expectLater(process.stdout, emits('HUP'));
     await process.kill();
   }, testOn: '!windows');
+
+  test('allows a long-running process', () async {
+    await startDartProcess(r'''
+      await Future.delayed(Duration(minutes: 10));
+    ''');
+    // Test should not time out.
+  });
 }
 
 /// Starts a Dart process running [script] in a main method.


### PR DESCRIPTION
Closes dart-lang/test#2429

This check does not seem to serve a useful purpose - most tests which
care about the process existing will already be using `shouldExit`.
Since we have a `kill` in the teardown, we may as well not force the
test to timeout before hitting it.
